### PR TITLE
berks update was failing

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'midas'
 version '0.0.1'
 
-depends 'postgresql', '~> 3.4.4'
+depends 'postgresql'
 depends 'user'
 #depends 'nginx'
 depends 'nodejs'


### PR DESCRIPTION
error was this: 
Unable to satisfy constraints on package postgresql due to solution constraint (postgresql = 0.16.0). Solution constraints that may result in a constraint on postgresql: [(midas = 0.0.1) -> (postgresql ~> 3.4.4)], [(midas = 0.0.1) -> (database = 1.1.0) -> (postgresql >= 0.0.0)], [(midas = 0.0.1) -> (database = {1.3.4,2.3.0,2.1.0,2.3.1}) -> (postgresql >= 1.0.0)], [(postgresql = 0.16.0)]
Demand that cannot be met: (postgresql = 0.16.0)
Artifacts for which there are conflicting dependencies: postgresql = 0.16.0 -> [(apt >= 1.9.0)]Unable to find a solution for demands: apt (>= 0.0.0), build-essential (>= 0.0.0), citadel (1.0.2), midas (0.0.1), nginx (>= 0.0.0), nodejs (>= 0.0.0), postgresql (0.16.0)
