### PR TITLE
[Not ready] Add session store

### DIFF
--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -22,6 +22,12 @@ postgresql_database_user node['midas']['database']['username'] do
   action :create
 end
 
+postgresql_database node['midas']['database']['name']  do
+  connection db_connection_info
+  sql { ::File.open(node.midas.deploy_dir + '/node_modules/connect-pg-simple/table.sql').read }
+  action :query
+end
+
 postgresql_database_user node['midas']['database']['username'] do
   connection db_connection_info
   database_name node['midas']['database']['name']

--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -22,11 +22,6 @@ postgresql_database_user node['midas']['database']['username'] do
   action :create
 end
 
-execute 'set up session table' do
-  command "psql node['midas']['database']['name'] < node_modules/connect-pg-simple/table.sql"
-  cwd node.midas.deploy_dir
-end
-
 postgresql_database_user node['midas']['database']['username'] do
   connection db_connection_info
   database_name node['midas']['database']['name']

--- a/recipes/db.rb
+++ b/recipes/db.rb
@@ -22,10 +22,9 @@ postgresql_database_user node['midas']['database']['username'] do
   action :create
 end
 
-postgresql_database node['midas']['database']['name']  do
-  connection db_connection_info
-  sql { ::File.open(node.midas.deploy_dir + '/node_modules/connect-pg-simple/table.sql').read }
-  action :query
+execute 'set up session table' do
+  command "psql node['midas']['database']['name'] < node_modules/connect-pg-simple/table.sql"
+  cwd node.midas.deploy_dir
 end
 
 postgresql_database_user node['midas']['database']['username'] do

--- a/templates/default/local.js.erb
+++ b/templates/default/local.js.erb
@@ -1,6 +1,10 @@
-var fs = require('fs');
+var fs = require('fs'),
+    pgSession = require('connect-pg-simple'),
+    express = require('sails/node_modules/express'),
+    pg = require('sails-postgresql/node_modules/pg'),
+    local;
 
-module.exports = {
+local = {
   systemName: '<%= @app_id %>',
   httpProtocol: 'https',
   hostName: '<%= @app_host %>',
@@ -65,3 +69,13 @@ module.exports = {
   systemEmail: '<%= @app_system_email %>'
 
 };
+
+// Use main postgres database for sessions
+local.session = {
+  store: new (pgSession(express.session))({
+    conString: local.connections.postgresql,
+    pg: pg
+  })
+};
+
+module.exports = local;


### PR DESCRIPTION
Adds session settings that use the main postgres database for share sessions. This should make the application stateless so it can autoscale.

Needs an update to the [db setup](https://github.com/18F/midas-cookbook/blob/master/recipes/db.rb) for the following:

``` bash
psql midas < node_modules/connect-pg-simple/table.sql
psql midas -c "GRANT ALL PRIVILEGES ON TABLE session TO midas"
```
