### PR TITLE
Add settings for drafts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,3 +37,6 @@ default.midas.linkedin.secret = 'NOTSET'
 
 default.midas.myusa.client_id = 'NOTSET'
 default.midas.myusa.secret = 'NOTSET'
+
+default.midas.task_state = 'draft'
+default.midas.draft_admin_only = false

--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -36,7 +36,9 @@ template  "#{node.midas.deploy_dir}/config/local.js" do
     email_user: node.midas.email.username,
     email_password: node.midas.email.password,
     email_port: node.midas.email.port,
-    email_secure: node.midas.email.secure
+    email_secure: node.midas.email.secure,
+    task_state: node.midas.task_state,
+    draft_admin_only: node.midas.draft_admin_only
   )
 end
 

--- a/recipes/ec2_vars.rb
+++ b/recipes/ec2_vars.rb
@@ -6,4 +6,5 @@ if node[:ec2]
   node.set['midas']['myusa']['secret'] = citadel["#{prefix}/myusa_secret"].strip
   node.set['midas']['linkedin']['client_id'] = citadel["#{prefix}/linkedin_client_id"].strip
   node.set['midas']['linkedin']['secret'] = citadel["#{prefix}/linkedin_secret"].strip
+  node.set['midas']['draft_admin_only'] = citadel["#{prefix}/draft_admin_only"].strip
 end

--- a/templates/default/local.js.erb
+++ b/templates/default/local.js.erb
@@ -33,6 +33,10 @@ module.exports = {
     layoutDir: 'assets/email/layouts'
   },
 
+  // Default task state
+  taskState: '<%= task_state %>',
+  draftAdminOnly: <%= draft_admin_only %>,
+
   emailProtocol: 'SMTP',
   smtp: {
     service             : '',


### PR DESCRIPTION
Adds `taskState` and `draftAdminOnly` settings to the local.js template and sets related variables and default values.
