### PR TITLE
Set up New Relic environment vars

### DIFF
--- a/recipes/app.rb
+++ b/recipes/app.rb
@@ -39,10 +39,6 @@ template  "#{node.midas.deploy_dir}/config/local.js" do
     email_secure: node.midas.email.secure,
     email_cc: node.midas.email.cc,
     email_bcc: node.midas.email.bcc,
-    newrelic_enabled: node.midas.newrelic.enabled,
-    newrelic_appname: node.midas.newrelic.appname,
-    newrelic_licensekey: node.midas.newrelic.licensekey,
-    newrelic_loglevel: node.midas.newrelic.loglevel,
     task_state: node.midas.task_state,
     draft_admin_only: node.midas.draft_admin_only,
     app_host: node.midas.app_host,
@@ -143,6 +139,8 @@ template "/etc/init/midas.conf" do
   variables(
     working_dir: node.midas.deploy_dir,
     app_user: node.midas.user,
+    newrelic_appname: node.midas.newrelic.appname,
+    newrelic_licensekey: node.midas.newrelic.licensekey
   )
 end
 

--- a/templates/default/local.js.erb
+++ b/templates/default/local.js.erb
@@ -69,19 +69,6 @@ module.exports = {
 
   systemEmail: '<%= @app_system_email %>',
 
-  newrelic: {
-    newrelicEnabled: <%= @newrelic_enabled %>,
-    newrelic: {
-      // Array of application names, as they will appear in the New Relic interface.
-      app_name : ['<%= @newrelic_appname %>'],
-      // Your New Relic license key.
-      license_key : '<%= @newrelic_licensekey %>',
-      logging : {
-        level : '<%= @newrelic_loglevel %>'
-      }
-    },
-  },
-
   auth: {
     auth: {
       local : {

--- a/templates/default/midas.upstart.erb
+++ b/templates/default/midas.upstart.erb
@@ -6,6 +6,9 @@ stop on shutdown
 respawn
 respawn limit 10 5
 
+env NEW_RELIC_LICENSE_KEY=<%= @newrelic_appname %>
+env NEW_RELIC_APP_NAME=<%= @newrelic_licensekey %>
+
 setuid <%= @app_user %>
 
 chdir <%= @working_dir %>


### PR DESCRIPTION
With https://github.com/18F/midas/pull/571, Midas now includes New Relic when the license key and app name are set as environment variables. This sets those vars in the upstart script.
