### PR TITLE
Add static route in nginx for robots.txt

### DIFF
--- a/templates/default/midas.conf.erb
+++ b/templates/default/midas.conf.erb
@@ -18,6 +18,11 @@ server {
     proxy_hide_header X-Powered-By;
   }
 
+  # Deny search engine indexing
+  location /robots.txt {
+      return 200 "User-agent: *\nDisallow: /";
+  }
+
   client_max_body_size 10M;
 
   gzip on;


### PR DESCRIPTION
Adds a static route for `/robots.txt` that returns

```
User-agent: *
Disallow: /
```

to block search engine indexing.
