### PR TITLE
Include new registration configuration options

### DIFF
--- a/templates/default/local.js.erb
+++ b/templates/default/local.js.erb
@@ -77,7 +77,7 @@ module.exports = {
   },
 
   systemEmail: '<%= @app_system_email %>',
-  
+
   /**
    * Store files on AWS S3
    * Useful for multi-server hosting environments
@@ -98,6 +98,7 @@ module.exports = {
     }
   },
   
-  validateDomains: ('<%= @app_host %>' === 'midas-dev.18f.us') ? false : true
-
+  validateDomains: ('<%= @app_host %>' === 'midas-dev.18f.us') ? false : true,
+  requireAgency: ('<%= @app_host %>' === 'midas-dev.18f.us') ? false : true,
+  requireLocation: ('<%= @app_host %>' === 'midas-dev.18f.us') ? false : true
 };


### PR DESCRIPTION
In [18f/midas#917](https://github.com/18F/midas/pull/917) we give deployers of the platform an option to require agency or/and location when a user signs up. We want to require these things on our production environment, so I set them here in our cookbook.

Those variables are:
- `requireAgency`
- `requireLocation`
