### PR TITLE
Update npm when building a new server

### DIFF
--- a/recipes/node_modules.rb
+++ b/recipes/node_modules.rb
@@ -1,3 +1,9 @@
+# update npm
+execute 'update npm' do
+  command "npm npm install npm@2.1.x -g"
+  cwd node.midas.deploy_dir
+  user node.midas.user
+end
 
 user node.midas.user do
   supports :manage_home => true


### PR DESCRIPTION
To prevent a build error that happens with older npm, we need to make sure npm is updated to v2.1.x
